### PR TITLE
IMTA-4685 - Azure Search Indexes: Special Characters Not Escaped

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Spring Boot Common Security
+# Spring Boot Common
 
 ## Common Health library
 

--- a/azure/checkstyle-suppressions.xml
+++ b/azure/checkstyle-suppressions.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+  "-//Puppy Crawl//DTD Suppressions 1.0//EN"
+  "http://www.puppycrawl.com/dtds/suppressions_1_0.dtd">
+
+<suppressions>
+  <suppress checks="JavadocPackage" files=".*[\\/]src[\\/]"/>
+  <suppress checks="JavadocMethod" files=".*[\\/]src[\\/]"/>
+</suppressions>

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -1,0 +1,101 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>uk.gov.defra.tracesx</groupId>
+  <artifactId>TracesX-SpringBoot-Common-Azure</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+  <name>azure</name>
+
+  <properties>
+    <maven.compiler.source.version>1.8</maven.compiler.source.version>
+    <maven.compiler.target.version>1.8</maven.compiler.target.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <spring.boot.version>2.0.5.RELEASE</spring.boot.version>
+    <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
+  </properties>
+
+  <distributionManagement>
+    <repository>
+      <id>release</id>
+      <name>Releases</name>
+      <url>${repo.releases.url}</url>
+    </repository>
+  </distributionManagement>
+
+  <scm>
+    <connection>${parent.scm.connection}</connection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring.boot.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.lucene</groupId>
+      <artifactId>lucene-queries</artifactId>
+      <version>7.5.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
+      <scope>compile</scope>
+    </dependency>
+    <!-- TEST Dependencies -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-checkstyle-plugin</artifactId>
+          <version>${maven.checkstyle.version}</version>
+          <configuration>
+            <configLocation>google_checks.xml</configLocation>
+            <logViolationsToConsole>true</logViolationsToConsole>
+            <outputFile>${project.build.directory}/checkstyle-result.xml</outputFile>
+            <violationSeverity>warning</violationSeverity>
+            <failsOnError>true</failsOnError>
+            <suppressionsLocation>checkstyle-suppressions.xml</suppressionsLocation>
+            <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
+          </configuration>
+          <executions>
+            <execution>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.7.0</version>
+        <configuration>
+          <source>${maven.compiler.source.version}</source>
+          <target>${maven.compiler.target.version}</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/azure/src/main/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilder.java
+++ b/azure/src/main/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilder.java
@@ -1,0 +1,47 @@
+package uk.gov.defra.tracesx.common.azure;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SearchQueryBuilder {
+
+  private static final List<String> AZURE_SEARCH_SPECIAL_CHARACTERS = Arrays
+      .asList("+", "-", "&&", "||", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", "*", "?",
+          ":", "\\", "/");
+  private static final String ESCAPE_PREFIX = "\\";
+
+  public Query createWildcardSearchQuery(String field, String value) {
+    String escapedValue = escapeMetaCharacters(value);
+    String updatedValue = hasAzureSpecialCharacters(escapedValue)
+        ? escapedValue
+        : String.format("%s*", escapedValue);
+    return createSearchQuery(field, updatedValue);
+  }
+
+  private Boolean hasAzureSpecialCharacters(String value) {
+    return !AZURE_SEARCH_SPECIAL_CHARACTERS.stream()
+        .filter(value::contains)
+        .collect(Collectors.toList())
+        .isEmpty();
+  }
+
+  private Query createSearchQuery(String field, String value) {
+    return new TermQuery(new Term(field, value));
+  }
+
+  private String escapeMetaCharacters(String inputString) {
+    String escapedString = inputString;
+    for (String specialCharacter : AZURE_SEARCH_SPECIAL_CHARACTERS) {
+      escapedString = StringUtils.replace(escapedString,
+          specialCharacter,
+          ESCAPE_PREFIX.concat(specialCharacter));
+    }
+    return escapedString;
+  }
+}

--- a/azure/src/test/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilderTest.java
+++ b/azure/src/test/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilderTest.java
@@ -1,0 +1,39 @@
+package uk.gov.defra.tracesx.common.azure;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.lucene.search.Query;
+import org.junit.Before;
+import org.junit.Test;
+
+public class SearchQueryBuilderTest {
+
+  private static final String FIELD_NAME = "test-field";
+
+  private SearchQueryBuilder searchQueryBuilder;
+
+  @Before
+  public void setUp() {
+    searchQueryBuilder = new SearchQueryBuilder();
+  }
+
+  @Test
+  public void createWildcardSearchQueryWithNoSpecialCharactersReturnsCorrectQuery() {
+    String value = "abcdefg";
+
+    Query query = searchQueryBuilder.createWildcardSearchQuery(FIELD_NAME, value);
+
+    assertEquals("test-field:abcdefg*", query.toString());
+  }
+
+  @Test
+  public void createWildcardSearchQueryWithSpecialCharactersReturnsCorrectQuery() {
+    String value = "abcde+-&&||!(){}[]^\"~*?:\\/fg";
+
+    Query query = searchQueryBuilder.createWildcardSearchQuery(FIELD_NAME, value);
+
+    assertEquals(
+        "test-field:abcde\\\\+\\\\-\\\\&&\\\\||\\\\!\\\\(\\\\)\\\\{\\\\}\\\\[\\\\]\\\\^\\\\\"\\\\~\\\\*\\\\?\\\\:\\\\\\/fg",
+        query.toString());
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
   </scm>
 
   <modules>
+    <module>azure</module>
     <module>health</module>
     <module>health-tests</module>
   </modules>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Nicholas Martin |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [IMTA-4685 - Azure Search Indexes: Specia...](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/9) |
> | **GitLab MR Number** | [9](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/9) |
> | **Date Originally Opened** | Tue, 14 May 2019 |
> | **Approved on GitLab by** | Ghost User, Roy Morgan, marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

This is a common component to consistently handle escaping of values in Azure search queries - this code is a modified / fixed version of the code used in the economic operator, approved establishments and laboratories microservices.