### PR TITLE
IMTA-4685 - Azure Search Indexes: Special Characters Not Escaped

### DIFF
--- a/azure/src/main/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilder.java
+++ b/azure/src/main/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilder.java
@@ -7,7 +7,6 @@ import org.apache.lucene.search.TermQuery;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class SearchQueryBuilder {
 
@@ -17,31 +16,24 @@ public class SearchQueryBuilder {
   private static final String ESCAPE_PREFIX = "\\";
 
   public Query createWildcardSearchQuery(String field, String value) {
-    String escapedValue = escapeMetaCharacters(value);
-    String updatedValue = hasAzureSpecialCharacters(escapedValue)
-        ? escapedValue
-        : String.format("%s*", escapedValue);
-    return createSearchQuery(field, updatedValue);
-  }
-
-  private Boolean hasAzureSpecialCharacters(String value) {
-    return !AZURE_SEARCH_SPECIAL_CHARACTERS.stream()
-        .filter(value::contains)
-        .collect(Collectors.toList())
-        .isEmpty();
+    return createSearchQuery(field, escapeSpecialCharacters(value));
   }
 
   private Query createSearchQuery(String field, String value) {
     return new TermQuery(new Term(field, value));
   }
 
-  private String escapeMetaCharacters(String inputString) {
-    String escapedString = inputString;
+  private String escapeSpecialCharacters(String inputValue) {
+    String escapedValue = inputValue;
     for (String specialCharacter : AZURE_SEARCH_SPECIAL_CHARACTERS) {
-      escapedString = StringUtils.replace(escapedString,
+      escapedValue = StringUtils.replace(escapedValue,
           specialCharacter,
           ESCAPE_PREFIX.concat(specialCharacter));
     }
-    return escapedString;
+    return !escapedValue.equals(inputValue) ? escapedValue : String.format("%s*", inputValue);
+  }
+
+  public String createWildcardSearchValue(String value) {
+    return escapeSpecialCharacters(value);
   }
 }

--- a/azure/src/test/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilderTest.java
+++ b/azure/src/test/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilderTest.java
@@ -9,6 +9,11 @@ import org.junit.Test;
 public class SearchQueryBuilderTest {
 
   private static final String FIELD_NAME = "test-field";
+  private static final String FIELD_NAME_AS_STRING = "test-field:";
+  private static final String VALUE_NO_SPECIAL_CHARS = "abcdefg";
+  private static final String VALUE_SPECIAL_CHARS = "abcde+-&&||!(){}[]^\"~*?:\\/fg";
+  private static final String ESCAPED_VALUE_SPECIAL_CHARS =
+      "abcde\\\\+\\\\-\\\\&&\\\\||\\\\!\\\\(\\\\)\\\\{\\\\}\\\\[\\\\]\\\\^\\\\\"\\\\~\\\\*\\\\?\\\\:\\\\\\/fg";
 
   private SearchQueryBuilder searchQueryBuilder;
 
@@ -19,21 +24,29 @@ public class SearchQueryBuilderTest {
 
   @Test
   public void createWildcardSearchQueryWithNoSpecialCharactersReturnsCorrectQuery() {
-    String value = "abcdefg";
+    Query query = searchQueryBuilder.createWildcardSearchQuery(FIELD_NAME, VALUE_NO_SPECIAL_CHARS);
 
-    Query query = searchQueryBuilder.createWildcardSearchQuery(FIELD_NAME, value);
-
-    assertEquals("test-field:abcdefg*", query.toString());
+    assertEquals(FIELD_NAME_AS_STRING + VALUE_NO_SPECIAL_CHARS + "*", query.toString());
   }
 
   @Test
   public void createWildcardSearchQueryWithSpecialCharactersReturnsCorrectQuery() {
-    String value = "abcde+-&&||!(){}[]^\"~*?:\\/fg";
+    Query query = searchQueryBuilder.createWildcardSearchQuery(FIELD_NAME, VALUE_SPECIAL_CHARS);
 
-    Query query = searchQueryBuilder.createWildcardSearchQuery(FIELD_NAME, value);
+    assertEquals(FIELD_NAME_AS_STRING + ESCAPED_VALUE_SPECIAL_CHARS, query.toString());
+  }
 
-    assertEquals(
-        "test-field:abcde\\\\+\\\\-\\\\&&\\\\||\\\\!\\\\(\\\\)\\\\{\\\\}\\\\[\\\\]\\\\^\\\\\"\\\\~\\\\*\\\\?\\\\:\\\\\\/fg",
-        query.toString());
+  @Test
+  public void createWildcardSearchValueWithNoSpecialCharactersReturnsCorrectValue() {
+    String value = searchQueryBuilder.createWildcardSearchValue(VALUE_NO_SPECIAL_CHARS);
+
+    assertEquals(VALUE_NO_SPECIAL_CHARS + "*", value);
+  }
+
+  @Test
+  public void createWildcardSearchValueWithSpecialCharactersReturnsCorrectValue() {
+    String value = searchQueryBuilder.createWildcardSearchValue(VALUE_SPECIAL_CHARS);
+
+    assertEquals(ESCAPED_VALUE_SPECIAL_CHARS, value);
   }
 }


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Nicholas Martin |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [IMTA-4685 - Azure Search Indexes: Specia...](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/10) |
> | **GitLab MR Number** | [10](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/10) |
> | **Date Originally Opened** | Thu, 16 May 2019 |
> | **Approved on GitLab by** | Ghost User, Roy Morgan |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Provide an alternative way to escape special characters for the notification micro-service's Azure implementation.