### PR TITLE
IMTA-4685 - Azure Search Indexes: Special Characters Not Escaped

### DIFF
--- a/azure/src/main/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilder.java
+++ b/azure/src/main/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilder.java
@@ -11,8 +11,8 @@ import java.util.List;
 public class SearchQueryBuilder {
 
   private static final List<String> AZURE_SEARCH_SPECIAL_CHARACTERS = Arrays
-      .asList("+", "-", "&&", "||", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", "*", "?",
-          ":", "\\", "/");
+      .asList("\\", "+", "-", "&&", "||", "!", "(", ")", "{", "}", "[", "]", "^", "\"", "~", "*",
+          "?", ":", "/");
   private static final String ESCAPE_PREFIX = "\\";
 
   public Query createWildcardSearchQuery(String field, String value) {

--- a/azure/src/test/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilderTest.java
+++ b/azure/src/test/java/uk/gov/defra/tracesx/common/azure/SearchQueryBuilderTest.java
@@ -13,7 +13,7 @@ public class SearchQueryBuilderTest {
   private static final String VALUE_NO_SPECIAL_CHARS = "abcdefg";
   private static final String VALUE_SPECIAL_CHARS = "abcde+-&&||!(){}[]^\"~*?:\\/fg";
   private static final String ESCAPED_VALUE_SPECIAL_CHARS =
-      "abcde\\\\+\\\\-\\\\&&\\\\||\\\\!\\\\(\\\\)\\\\{\\\\}\\\\[\\\\]\\\\^\\\\\"\\\\~\\\\*\\\\?\\\\:\\\\\\/fg";
+      "abcde\\+\\-\\&&\\||\\!\\(\\)\\{\\}\\[\\]\\^\\\"\\~\\*\\?\\:\\\\\\/fg";
 
   private SearchQueryBuilder searchQueryBuilder;
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Nicholas Martin |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [IMTA-4685 - Azure Search Indexes: Specia...](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/11) |
> | **GitLab MR Number** | [11](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/11) |
> | **Date Originally Opened** | Thu, 16 May 2019 |
> | **Approved on GitLab by** | Ghost User, Roy Morgan |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Fix to allow notification service to use common special character escaping in Azure - note that in the case of search values which do not have special characters then no wildcard value is required.