### PR TITLE
IMTA-6780: Set the sonar properties to report code coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,4 @@ javaLibraryPipeline {
    SONARQUBE_PROJECT_NAME = "Imports-spring-boot-common"
    SERVICE_VERSION = "1.0"
    SELENIUM_BRANCH = "master"
-   JAVA_VERSION = "11"
 }

--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -27,4 +27,13 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -109,6 +109,10 @@
                     <sourcepath>${lombok-maven-plugin.outputDirectory}</sourcepath>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+            </plugin>
         </plugins>
     </build>
 

--- a/health-tests/pom.xml
+++ b/health-tests/pom.xml
@@ -42,4 +42,13 @@
       <artifactId>hamcrest-library</artifactId>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -67,4 +67,13 @@
       </exclusions>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
     <applicationinsights-core.version>2.5.0</applicationinsights-core.version>
     <azure-eventhubs.version>3.0.1</azure-eventhubs.version>
     <checkstyle.version>3.0.0</checkstyle.version>
+    <io.github.resilience4j.version>1.1.0</io.github.resilience4j.version>
+    <jacoco.maven.plugin.version>0.8.4</jacoco.maven.plugin.version>
     <javax.el.version>3.0.0</javax.el.version>
     <lucene.version>8.2.0</lucene.version>
     <lombok-maven-plugin.version>1.18.6.0</lombok-maven-plugin.version>
@@ -34,7 +36,6 @@
     <org.glassfish.web.javax.el.version>2.2.6</org.glassfish.web.javax.el.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <outputDirectory>${lombok-maven-plugin.outputDirectory}</outputDirectory>
-    <io.github.resilience4j.version>1.1.0</io.github.resilience4j.version>
   </properties>
 
   <scm>
@@ -148,6 +149,49 @@
             <phase>generate-sources</phase>
             <goals>
               <goal>delombok</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.maven.plugin.version}</version>
+        <configuration>
+          <excludes>
+            <exclude>**/traceswsns/**/*</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit implementation="org.jacoco.report.check.Limit">
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>report-agent</id>
+            <goals>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>

--- a/runJunit.sh
+++ b/runJunit.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-mvn test -f pom.xml
+export JAVA_HOME=$JAVA_HOME_11
+mvn clean test jacoco:report -f pom.xml -Dmaven.repo.local=${WORKSPACE}/.m2

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,16 @@
 sonar.projectKey=Imports-SpringBoot-Common
 
+#List of module identifiers
+sonar.modules=azure,event,health
+
 #By default include everything, use specific exclusions
-sonar.exclusions=common-health/src/main/resources/**
-sonar.coverage.exclusions=**
-sonar.java.binaries=.
-sonar.sources=.
-sonar.java.source=1.8
+sonar.java.binaries=target/classes
+sonar.java.test.binaries=target/test-classes
+sonar.tests=src/test/java
+sonar.sources=src/main/java
+sonar.java.source=11
+sonar.sourceEncoding=UTF-8
+sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+sonar.dynamicAnalysis=reuseReports
+sonar.junit.reportPaths=target/surefire-reports
+health.sonar.exclusions=src/main/resources/**


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | marcus bond (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [IMTA-6780: Set the sonar properties to r...](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/32) |
> | **GitLab MR Number** | [32](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/32) |
> | **Date Originally Opened** | Thu, 12 Mar 2020 |
> | **Approved on GitLab by** | Ghost User, daniel brennan (KAINOS), dominik henjes (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

IMTA-6780: Set the sonar to use the SonarQubeJunitQGNixClient passing java.libraries where applicable

https://eaflood.atlassian.net/browse/IMTA-6780
