### PR TITLE
IMTA-20021 vulnerability fixes

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -48,13 +48,14 @@
     <applicationinsights-core.version>3.4.19</applicationinsights-core.version>
     <azure.springboot.metricsstarter.version>2.3.5</azure.springboot.metricsstarter.version>
     <azure.version>2.3.3</azure.version>
-    <azureidentity.version>1.11.2</azureidentity.version>
+    <azureidentity.version>1.16.1</azureidentity.version>
     <checkstyle.version>10.12.2</checkstyle.version>
     <commons.beanutils.version>1.9.4</commons.beanutils.version>
     <equalsverifier.version>3.15.1</equalsverifier.version>
     <everit-json-schema.version>1.14.4</everit-json-schema.version>
     <git-build-hook-maven-plugin.version>3.4.1</git-build-hook-maven-plugin.version>
-    <guava.version>32.1.2-jre</guava.version>
+    <guava.version>33.4.8-jre</guava.version>
+    <nimbus-jose-jwt.version>10.3</nimbus-jose-jwt.version>
     <hibernate.version>6.4.1.Final</hibernate.version>
     <io.micrometer.micrometer-core.version>1.11.3</io.micrometer.micrometer-core.version>
     <jacoco.maven.plugin.version>0.8.10</jacoco.maven.plugin.version>
@@ -70,7 +71,7 @@
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <maven-remote-resources-plugin.version>3.1.0</maven-remote-resources-plugin.version>
     <maven.versions.plugin.version>2.16.0</maven.versions.plugin.version>
-    <mssql.jdbc.version>11.2.0.jre17</mssql.jdbc.version>
+    <mssql.jdbc.version>12.10.0.jre11</mssql.jdbc.version>
     <neovisionaries.version>1.29</neovisionaries.version>
     <org.owasp.encoder.version>1.2.3</org.owasp.encoder.version>
     <shared-resources.version>1.0.1</shared-resources.version>
@@ -146,6 +147,17 @@
         <groupId>com.azure</groupId>
         <artifactId>azure-identity</artifactId>
         <version>${azureidentity.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>nimbus-jose-jwt</artifactId>
+        <version>${nimbus-jose-jwt.version}</version>
       </dependency>
       <dependency>
         <groupId>com.github.fge</groupId>
@@ -251,10 +263,6 @@
       <artifactId>spring-boot-starter-validation</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.azure</groupId>
-      <artifactId>azure-identity</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
@@ -289,12 +297,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>com.vaadin.external.google</groupId>
-          <artifactId>android-json</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,11 @@
 
     <applicationinsights-core.version>3.4.19</applicationinsights-core.version>
     <azure-eventhubs.version>3.3.0</azure-eventhubs.version>
-    <nimbus-jose-jwt.version>9.23</nimbus-jose-jwt.version>
+    <adal4j.version>1.6.7</adal4j.version>
+    <azure-client-runtime.verson>1.7.14</azure-client-runtime.verson>
+    <azure-client-authentication.version>1.7.14</azure-client-authentication.version>
+    <logging-interceptor.version>4.12.0</logging-interceptor.version>
+    <nimbus-jose-jwt.version>10.3</nimbus-jose-jwt.version>
     <maven.checkstyle.version>3.2.1</maven.checkstyle.version>
     <maven-compiler-plugin.version>3.11.0</maven-compiler-plugin.version>
     <maven.deploy.plugin.version>3.1.1</maven.deploy.plugin.version>
@@ -35,6 +39,7 @@
     <jacoco.maven.plugin.version>0.8.10</jacoco.maven.plugin.version>
     <javax.el.version>3.0.0</javax.el.version>
     <lucene.version>8.2.0</lucene.version>
+    <guava.version>33.4.8-jre</guava.version>
     <lombok-maven-plugin.version>1.18.20.0</lombok-maven-plugin.version>
     <lombok-maven-plugin.outputDirectory>${project.build.directory}/generated-sources/delombok</lombok-maven-plugin.outputDirectory>
     <org.glassfish.jakarta.el.version>5.0.0-M1</org.glassfish.jakarta.el.version>
@@ -105,13 +110,50 @@
             <groupId>com.nimbusds</groupId>
             <artifactId>nimbus-jose-jwt</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>adal4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-client-runtime</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.squareup.okhttp3</groupId>
+            <artifactId>logging-interceptor</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.microsoft.azure</groupId>
+            <artifactId>azure-client-authentication</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <!-- Exclude guava from everywhere and add an OWASP friendly version of 30 + -->
       <dependency>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>adal4j</artifactId>
+        <version>${adal4j.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-client-runtime</artifactId>
+        <version>${azure-client-runtime.verson}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okhttp3</groupId>
+        <artifactId>logging-interceptor</artifactId>
+        <version>${logging-interceptor.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.microsoft.azure</groupId>
+        <artifactId>azure-client-authentication</artifactId>
+        <version>${azure-client-authentication.version}</version>
+        <scope>compile</scope>
+      </dependency>
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>30.1-jre</version>
+        <version>${guava.version}</version>
       </dependency>
       <dependency>
         <groupId>javax.el</groupId>

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -59,6 +59,7 @@
     <dependency>
       <groupId>com.nimbusds</groupId>
       <artifactId>nimbus-jose-jwt</artifactId>
+      <version>${nimbus-jose-jwt.version}</version>
     </dependency>
     <!-- used to fetch public signing keys from jwks urls -->
     <dependency>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | @tarun-palisetty |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [IMTA-20021 vulnerability fixes](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/80) |
> | **GitLab MR Number** | [80](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/80) |
> | **Date Originally Opened** | Fri, 16 May 2025 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Fixed the below CVE

➜  **spring-boot-common git:(master)** mvn --settings ~/Workspace/DEFRA/files/settings.xml org.owasp:dependency-check-maven:8.4.3:check -Dformat=JSON -DprettyPrint=true | grep -i CVE-
1. adal4j-1.6.4.jar (pkg:maven/com.microsoft.azure/adal4j@1.6.4, cpe:2.3:a:microsoft:azure_active_directory:1.6.4:*:*:*:*:*:*:*) : CVE-2021-42306
1. azure-client-runtime-1.7.3.jar (pkg:maven/com.microsoft.azure/azure-client-runtime@1.7.3, cpe:2.3:a:microsoft:azure_cli:1.7.3:*:*:*:*:*:*:*) : CVE-2024-43591, CVE-2023-36052
1. logging-interceptor-3.12.2.jar (pkg:maven/com.squareup.okhttp3/logging-interceptor@3.12.2, cpe:2.3:a:squareup:okhttp:3.12.2:*:*:*:*:*:*:*, cpe:2.3:a:squareup:okhttp3:3.12.2:*:*:*:*:*:*:*) : CVE-2023-0833
1. okhttp-3.12.6.jar (pkg:maven/com.squareup.okhttp3/okhttp@3.12.6, cpe:2.3:a:squareup:okhttp:3.12.6:*:*:*:*:*:*:*, cpe:2.3:a:squareup:okhttp3:3.12.6:*:*:*:*:*:*:*) : CVE-2021-0341, CVE-2023-0833
1. okhttp-urlconnection-3.12.2.jar (pkg:maven/com.squareup.okhttp3/okhttp-urlconnection@3.12.2, cpe:2.3:a:squareup:okhttp:3.12.2:*:*:*:*:*:*:*, cpe:2.3:a:squareup:okhttp3:3.12.2:*:*:*:*:*:*:*) : CVE-2023-0833
1. okio-1.15.0.jar (pkg:maven/com.squareup.okio/okio@1.15.0, cpe:2.3:a:squareup:okio:1.15.0:*:*:*:*:*:*:*) : CVE-2023-3635
1. azure-identity-1.11.2.jar (pkg:maven/com.azure/azure-identity@1.11.2, cpe:2.3:a:microsoft:azure_identity_sdk:1.11.2:*:*:*:*:*:*:*, cpe:2.3:a:microsoft:azure_sdk_for_java:1.11.2:*:*:*:*:*:*:*) : CVE-2023-36415, CVE-2024-35255
1. msal4j-1.14.0.jar (pkg:maven/com.microsoft.azure/msal4j@1.14.0, cpe:2.3:a:microsoft:authentication_library:1.14.0:*:*:*:*:*:*:*) : CVE-2024-35255
1. nimbus-jose-jwt-9.30.2.jar (pkg:maven/com.nimbusds/nimbus-jose-jwt@9.30.2, cpe:2.3:a:connect2id:nimbus_jose\+jwt:9.30.2:*:*:*:*:*:*:*) : CVE-2023-52428
1. guava-30.1-jre.jar (pkg:maven/com.google.guava/guava@30.1-jre, cpe:2.3:a:google:guava:30.1:*:*:*:*:*:*:*) : CVE-2023-2976, CVE-2020-8908
1. nimbus-jose-jwt-9.23.jar/META-INF/maven/net.minidev/json-smart/pom.xml (pkg:maven/net.minidev/json-smart@2.4.8, cpe:2.3:a:json-smart_project:json-smart:2.4.8:*:*:*:*:*:*:*, cpe:2.3:a:json-smart_project:json-smart-v2:2.4.8:*:*:*:*:*:*:*) : CVE-2023-1370
1. nimbus-jose-jwt-9.23.jar (pkg:maven/com.nimbusds/nimbus-jose-jwt@9.23, cpe:2.3:a:connect2id:nimbus_jose\+jwt:9.23:*:*:*:*:*:*:*) : CVE-2023-52428