### PR TITLE
Feature/imta 5844 resolve vulnerabilities

### DIFF
--- a/azure/pom.xml
+++ b/azure/pom.xml
@@ -6,11 +6,24 @@
   <version>1.0.11-SNAPSHOT</version>
   <name>azure</name>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-dependencies</artifactId>
+    <version>2.0.9.RELEASE</version>
+  </parent>
+
   <properties>
-    <maven.compiler.source.version>1.8</maven.compiler.source.version>
-    <maven.compiler.target.version>1.8</maven.compiler.target.version>
+    <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.boot.version>2.0.5.RELEASE</spring.boot.version>
+
+    <!-- Spring Boot dependency version overrides -->
+    <commons.lang3.version>3.8.1</commons.lang3.version>
+    <jackson.version>2.9.10</jackson.version>
+    <!-- End Spring Boot dependency version overrides -->
+
+    <lucene-queries.version>7.5.0</lucene-queries.version>
     <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
   </properties>
 
@@ -27,29 +40,15 @@
     <tag>HEAD</tag>
   </scm>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
-
   <dependencies>
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-queries</artifactId>
-      <version>7.5.0</version>
+      <version>${lucene-queries.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.7</version>
-      <scope>compile</scope>
     </dependency>
     <!-- TEST Dependencies -->
     <dependency>
@@ -89,11 +88,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <source>${maven.compiler.source.version}</source>
-          <target>${maven.compiler.target.version}</target>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/event/pom.xml
+++ b/event/pom.xml
@@ -6,13 +6,28 @@
     <version>1.0.11-SNAPSHOT</version>
     <name>event</name>
 
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>2.0.9.RELEASE</version>
+    </parent>
+
     <properties>
-        <maven.compiler.source.version>1.8</maven.compiler.source.version>
-        <maven.compiler.target.version>1.8</maven.compiler.target.version>
+        <java.version>1.8</java.version>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <spring.boot.version>2.0.5.RELEASE</spring.boot.version>
-        <restassured.version>3.3.0</restassured.version>
+
+        <!-- Spring Boot dependency version overrides -->
+        <jackson.version>2.9.10</jackson.version>
+        <!-- End Spring Boot dependency version overrides -->
+
+        <applicationinsights-core.version>2.3.1</applicationinsights-core.version>
+        <azure-eventhubs.version>2.2.0</azure-eventhubs.version>
+        <javax.el.version>3.0.0</javax.el.version>
         <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
+        <org.glassfish.web.javax.el.version>2.2.6</org.glassfish.web.javax.el.version>
+        <restassured.version>3.3.0</restassured.version>
     </properties>
 
     <distributionManagement>
@@ -28,65 +43,42 @@
         <tag>HEAD</tag>
     </scm>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-dependencies</artifactId>
-                <version>${spring.boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <dependency>
             <groupId>javax.validation</groupId>
             <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate.validator</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>6.0.12.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.hibernate.validator</groupId>
-            <artifactId>hibernate-validator</artifactId>
-            <version>6.0.12.Final</version>
         </dependency>
         <dependency>
             <groupId>javax.el</groupId>
             <artifactId>javax.el-api</artifactId>
-            <version>3.0.0</version>
+            <version>${javax.el.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.web</groupId>
             <artifactId>javax.el</artifactId>
-            <version>2.2.6</version>
+            <version>${org.glassfish.web.javax.el.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
-            <version>2.9.5</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.6</version>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>applicationinsights-core</artifactId>
-            <version>2.3.1</version>
+            <version>${applicationinsights-core.version}</version>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-eventhubs</artifactId>
-            <version>2.2.0</version>
+            <version>${azure-eventhubs.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -113,12 +105,6 @@
             <artifactId>spring-web</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <version>${restassured.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
         </dependency>
@@ -138,6 +124,12 @@
                     <artifactId>android-json</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>${restassured.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 
@@ -171,11 +163,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
-                <configuration>
-                    <source>${maven.compiler.source.version}</source>
-                    <target>${maven.compiler.target.version}</target>
-                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/health-tests/pom.xml
+++ b/health-tests/pom.xml
@@ -9,25 +9,25 @@
     Configuration
   </description>
 
-  <properties>
-    <maven.compiler.source.version>1.8</maven.compiler.source.version>
-    <maven.compiler.target.version>1.8</maven.compiler.target.version>
-    <spring.boot.version>2.0.5.RELEASE</spring.boot.version>
-    <restassured.version>3.3.0</restassured.version>
-    <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
-  </properties>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-dependencies</artifactId>
+    <version>2.0.9.RELEASE</version>
+  </parent>
 
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
+  <properties>
+    <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <!-- Spring Boot dependency version overrides -->
+    <jackson.version>2.9.10</jackson.version>
+    <!-- End Spring Boot dependency version overrides -->
+
+    <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
+    <restassured.version>3.3.0</restassured.version>
+  </properties>
 
   <distributionManagement>
     <repository>
@@ -88,11 +88,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <source>${maven.compiler.source.version}</source>
-          <target>${maven.compiler.target.version}</target>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/health/pom.xml
+++ b/health/pom.xml
@@ -6,13 +6,24 @@
   <version>1.0.11-SNAPSHOT</version>
   <name>health</name>
 
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-dependencies</artifactId>
+    <version>2.0.9.RELEASE</version>
+  </parent>
+
   <properties>
-    <maven.compiler.source.version>1.8</maven.compiler.source.version>
-    <maven.compiler.target.version>1.8</maven.compiler.target.version>
+    <java.version>1.8</java.version>
+    <maven.compiler.source>${java.version}</maven.compiler.source>
+    <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.boot.version>2.0.5.RELEASE</spring.boot.version>
-    <restassured.version>3.3.0</restassured.version>
+
+    <!-- Spring Boot dependency version overrides -->
+    <jackson.version>2.9.10</jackson.version>
+    <!-- End Spring Boot dependency version overrides -->
+
     <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
+    <restassured.version>3.3.0</restassured.version>
   </properties>
 
   <distributionManagement>
@@ -27,18 +38,6 @@
     <connection>${parent.scm.connection}</connection>
     <tag>HEAD</tag>
   </scm>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring.boot.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -124,11 +123,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
-        <configuration>
-          <source>${maven.compiler.source.version}</source>
-          <target>${maven.compiler.target.version}</target>
-        </configuration>
       </plugin>
     </plugins>
   </build>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | marcus bond (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [Feature/imta 5844 resolve vulnerabilitie...](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/17) |
> | **GitLab MR Number** | [17](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/17) |
> | **Date Originally Opened** | Tue, 1 Oct 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

- Move to latest 2.0.x version of spring boot
- Update Jackson
- Setup boot deps as parent to facilitate overriding groups of libs (e.g. Jackson) via spring boot parent property overrides (see https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto-customize-dependency-versions )
- Order props for consistency
