### PR TITLE
IMTA-8976: - OWASP HIGH - upgrade versions of Spring Boot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-dependencies</artifactId>
-    <version>2.2.5.RELEASE</version>
+    <version>2.4.2</version>
   </parent>
 
   <properties>
@@ -20,9 +20,6 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <!-- Spring Boot dependency version overrides -->
-    <jackson.version>2.10.1</jackson.version>
-    <!-- End Spring Boot dependency version overrides -->
 
     <applicationinsights-core.version>2.6.2</applicationinsights-core.version>
     <azure-eventhubs.version>3.1.1</azure-eventhubs.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bridget.hodgson (Kainos) |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [IMTA-8976: - OWASP HIGH - upgrade versio...](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/51) |
> | **GitLab MR Number** | [51](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/51) |
> | **Date Originally Opened** | Tue, 26 Jan 2021 |
> | **Approved on GitLab by** | Carl Evans (KAINOS), Reece Bennett (KAINOS), Stephen Donaghey (KAINOS), Stephen McVeigh, kingsley.Osime (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

* https://eaflood.atlassian.net/browse/IMTA-8976
* The services should use the same upgraded version for all of the spring boot jars.  Some are set here.