### PR TITLE
IMTA-11140 Spring Boot Upgrade to 2.6.2 to fix vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-dependencies</artifactId>
-    <version>2.3.8.RELEASE</version>
+    <version>2.6.2</version>
   </parent>
 
   <properties>
@@ -22,7 +22,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <applicationinsights-core.version>2.6.2</applicationinsights-core.version>
-    <azure-eventhubs.version>3.1.1</azure-eventhubs.version>
+    <azure-eventhubs.version>3.3.0</azure-eventhubs.version>
     <checkstyle.version>3.0.0</checkstyle.version>
     <io.github.resilience4j.version>1.1.0</io.github.resilience4j.version>
     <jacoco.maven.plugin.version>0.8.4</jacoco.maven.plugin.version>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Stephen Donaghey (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [IMTA-11140 Spring Boot Upgrade to 2.6.2 ...](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/53) |
> | **GitLab MR Number** | [53](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/53) |
> | **Date Originally Opened** | Tue, 18 Jan 2022 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Kelly Moore, Sean Treanor (KAINOS), kingsley.Osime (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: Ticket: https://eaflood.atlassian.net/browse/IMTA-11140

### :book: Changes:
* Upgrading to Spring Boot 2.6.2 and latest event hubs library