### PR TITLE
IMTA-13422: Return version info from function app

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <module>health</module>
     <module>health-tests</module>
     <module>logging</module>
+    <module>version</module>
   </modules>
 
   <distributionManagement>

--- a/version/LICENSE
+++ b/version/LICENSE
@@ -1,0 +1,8 @@
+The Open Government Licence (OGL) Version 3
+
+Copyright (c) 2021 Defra
+
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/version/README.md
+++ b/version/README.md
@@ -1,0 +1,20 @@
+## Common Version library
+
+This module defines an Azure Function http triggered endpoint to return the application version and name.
+
+### Steps to integrate
+
+Include the following library in your pom.xml
+
+```
+<dependency>
+    <groupId>uk.gov.defra.tracesx</groupId>
+    <artifactId>TracesX-SpringBoot-Common-Version</artifactId>
+    <version>desired version</version>
+</dependency>
+```
+
+The function uses the following environment variables:
+
+- `APP_NAME`
+- `API_VERSION`

--- a/version/pom.xml
+++ b/version/pom.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>TracesX-SpringBoot-Common-Version</artifactId>
+  <version>2.0.27-SNAPSHOT</version>
+  <name>version</name>
+
+  <parent>
+    <groupId>uk.gov.defra.tracesx</groupId>
+    <artifactId>TracesX-SpringBoot-Common</artifactId>
+    <version>2.0.27-SNAPSHOT</version>
+  </parent>
+
+  <scm>
+    <connection>${parent.scm.connection}</connection>
+    <tag>HEAD</tag>
+  </scm>
+
+  <properties>
+    <azure.functions.java.library.version>2.0.1</azure.functions.java.library.version>
+    <system-lambda.version>1.2.1</system-lambda.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.microsoft.azure.functions</groupId>
+      <artifactId>azure-functions-java-library</artifactId>
+      <version>${azure.functions.java.library.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-lambda</artifactId>
+      <version>${system-lambda.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/version/src/main/java/uk/gov/defra/tracesx/common/version/FunctionAppVersion.java
+++ b/version/src/main/java/uk/gov/defra/tracesx/common/version/FunctionAppVersion.java
@@ -1,0 +1,35 @@
+package uk.gov.defra.tracesx.common.version;
+
+import com.microsoft.azure.functions.HttpMethod;
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import com.microsoft.azure.functions.annotation.AuthorizationLevel;
+import com.microsoft.azure.functions.annotation.FunctionName;
+import com.microsoft.azure.functions.annotation.HttpTrigger;
+
+import java.util.Optional;
+
+public class FunctionAppVersion {
+
+  private static final String APP_NAME = "APP_NAME";
+  private static final String API_VERSION = "API_VERSION";
+
+  @FunctionName("FunctionAppVersion")
+  public HttpResponseMessage runVersion(
+          @HttpTrigger(name = "req",
+                  methods = {HttpMethod.GET},
+                  authLevel = AuthorizationLevel.ANONYMOUS,
+                  route = "app/info")
+                  HttpRequestMessage<Optional<String>> request) {
+
+    return request
+        .createResponseBuilder(HttpStatus.OK)
+        .header("Content-Type", "application/json")
+        .body(
+            String.format(
+                "{\"app\":{\"name\":\"%1$s\",\"version\":\"%2$s\"}}",
+                System.getenv(APP_NAME), System.getenv(API_VERSION)))
+        .build();
+  }
+}

--- a/version/src/test/java/uk/gov/defra/tracesx/common/version/FunctionAppVersionTest.java
+++ b/version/src/test/java/uk/gov/defra/tracesx/common/version/FunctionAppVersionTest.java
@@ -1,0 +1,43 @@
+package uk.gov.defra.tracesx.common.version;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.microsoft.azure.functions.HttpRequestMessage;
+import com.microsoft.azure.functions.HttpResponseMessage;
+import com.microsoft.azure.functions.HttpStatus;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+@ExtendWith(MockitoExtension.class)
+class FunctionAppVersionTest {
+
+  @Mock
+  HttpRequestMessage<Optional<String>> httpRequestMessage;
+  @Mock
+  HttpResponseMessage.Builder httpResponseMessageBuilder;
+
+  @Test
+  void runVersion_ReturnsApplicationInformation() throws Exception {
+    when(httpRequestMessage.createResponseBuilder(any())).thenReturn(httpResponseMessageBuilder);
+    when(httpResponseMessageBuilder.header(any(), any())).thenReturn(httpResponseMessageBuilder);
+    when(httpResponseMessageBuilder.body(any())).thenReturn(httpResponseMessageBuilder);
+    withEnvironmentVariable("APP_NAME", "test_app")
+        .and("API_VERSION", "1.2.3")
+        .execute(
+            () -> {
+              new FunctionAppVersion().runVersion(httpRequestMessage);
+            });
+
+    verify(httpRequestMessage).createResponseBuilder(HttpStatus.OK);
+    verify(httpResponseMessageBuilder).header("Content-Type", "application/json");
+    verify(httpResponseMessageBuilder)
+        .body("{\"app\":{\"name\":\"test_app\",\"version\":\"1.2.3\"}}");
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Carl Evans (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [IMTA-13422: Return version info from fun...](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/60) |
> | **GitLab MR Number** | [60](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/60) |
> | **Date Originally Opened** | Mon, 6 Mar 2023 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Eugene Fahy (Kainos), Reece Bennett (KAINOS), prabash balasuriya (kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13422)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-13422-function-apps-returning-version&id=Imports-SpringBoot-Common)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-common/job/feature%252FIMTA-13422-function-apps-returning-version/)

### :book: Changes:
* Added new module to return version from Azure functions using a http trigger.