### PR TITLE
IMTA-11429-exclude nimbus-jose-jwt from azure event hubs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,10 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <!-- Exclude guava from everywhere and add an OWASP friendly version of 30 + -->


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Jana Latzberg (Kainos) |
> | **GitLab Project** | [imports/spring-boot-common](https://giteux.azure.defra.cloud/imports/spring-boot-common) |
> | **GitLab Merge Request** | [IMTA-11429-exclude nimbus-jose-jwt from ...](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/57) |
> | **GitLab MR Number** | [57](https://giteux.azure.defra.cloud/imports/spring-boot-common/merge_requests/57) |
> | **Date Originally Opened** | Mon, 15 Aug 2022 |
> | **Approved on GitLab by** | Kelly Moore, Stephen Donaghey (KAINOS), Thomas Seelig (Kainos), ramkumar ramagopal (Kainos) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-11429)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-11429-exclude-update-nimbus-jose-jwt-versions&id=Imports-SpringBoot-Common)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-common/job/feature%2FIMTA-11429-exclude-update-nimbus-jose-jwt-versions/)

### :book: Changes:
* Nimbus-jose-jwt was updated but had to be actively excluded from the azure-event-hubs dependency
